### PR TITLE
Add Tabulator table, sej-load CLI, and data quality fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ uv sync
 
 The database is populated from a TSV file exported from the effort-tracking spreadsheet.
 
-```python
-from sej.importer import load_tsv
-
-load_tsv("path/to/data_anon.tsv", "sej.db")
+```
+uv run sej-load IET_2_8_26_anon.tsv IET_2_8_26_anon.db
 ```
 
 This wipes any existing data and reloads from the given file. The database file is created if it does not exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [project.scripts]
 sej-web = "sej.app:main"
+sej-load = "sej.importer:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/sej/app.py
+++ b/sej/app.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from flask import Flask, render_template
+from flask import Flask, jsonify, render_template
 
 from sej.queries import get_spreadsheet_rows
 
@@ -22,8 +22,13 @@ def create_app(db_path=None):
 
     @app.route("/")
     def index():
+        return render_template("index.html")
+
+    @app.route("/api/data")
+    def api_data():
         headers, rows = get_spreadsheet_rows(app.config["DB_PATH"])
-        return render_template("index.html", headers=headers, rows=rows)
+        data = [dict(zip(headers, row)) for row in rows]
+        return jsonify({"columns": headers, "data": data})
 
     return app
 

--- a/sej/queries.py
+++ b/sej/queries.py
@@ -4,7 +4,6 @@ import sqlite3
 from pathlib import Path
 
 from sej.db import get_connection
-from sej.importer import NON_PROJECT_CODE
 
 
 def _discover_months(conn: sqlite3.Connection) -> list[tuple[int, int]]:
@@ -79,18 +78,13 @@ def get_spreadsheet_rows(db_path: str | Path) -> tuple[list[str], list[list[str]
     ] + [_month_label(y, m) for y, m in months]
 
     result = []
-    prev_employee = None
     for row in rows:
         employee = row["employee_name"]
-        show_employee = "" if employee == prev_employee else employee
-        prev_employee = employee
 
         project_code = row["project_code"]
-        if project_code == NON_PROJECT_CODE:
-            project_code = "N/A"
 
         line = [
-            show_employee,
+            employee,
             row["group_name"],
             row["fund_code"] or "",
             row["source"] or "",

--- a/sej/templates/index.html
+++ b/sej/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>SEJ - Effort Allocations</title>
+    <link href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css" rel="stylesheet">
     <style>
         body {
             font-family: "Segoe UI", Arial, sans-serif;
@@ -10,51 +11,134 @@
             background: #f8f9fa;
         }
         h1 { margin-bottom: 0.5rem; }
-        table {
-            border-collapse: collapse;
-            width: 100%;
+        #toolbar { margin-bottom: 0.5rem; display: flex; align-items: center; gap: 8px; }
+        #col-picker { position: relative; display: inline-block; }
+        #col-dropdown {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: 0;
             background: #fff;
-            font-size: 0.85rem;
-        }
-        th, td {
             border: 1px solid #ccc;
-            padding: 4px 8px;
-            text-align: left;
-            white-space: nowrap;
+            padding: 8px 12px;
+            z-index: 100;
+            min-width: 180px;
+            max-height: 400px;
+            overflow-y: auto;
+            box-shadow: 2px 2px 6px rgba(0,0,0,0.2);
         }
-        thead th {
-            background: #343a40;
-            color: #fff;
-            position: sticky;
-            top: 0;
-            z-index: 1;
-        }
-        tbody tr:nth-child(even) { background: #f2f2f2; }
-        tbody tr:hover { background: #e2e6ea; }
-        tr.employee-start td { font-weight: bold; }
+        #col-dropdown.open { display: block; }
+        #col-dropdown label { display: block; cursor: pointer; padding: 3px 0; white-space: nowrap; }
+        button { cursor: pointer; padding: 4px 10px; }
+        #show-all-btn.active { background: #0d6efd; color: #fff; border-color: #0d6efd; }
     </style>
 </head>
 <body>
     <h1>Effort Allocations</h1>
-    <div style="overflow-x: auto;">
-        <table>
-            <thead>
-                <tr>
-                    {% for header in headers %}
-                    <th>{{ header }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in rows %}
-                <tr{% if row[0] %} class="employee-start"{% endif %}>
-                    {% for cell in row %}
-                    <td>{{ cell }}</td>
-                    {% endfor %}
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+    <div id="toolbar">
+        <div id="col-picker">
+            <button id="col-btn">Columns &#9660;</button>
+            <div id="col-dropdown"></div>
+        </div>
+        <button id="show-all-btn">Show all rows</button>
     </div>
+    <div id="table"></div>
+
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script>
+        const monthPattern = /January|February|March|April|May|June|July|August|September|October|November|December/;
+        const hiddenByDefault = new Set([
+            "Fund Code", "Source", "Account",
+            "Cost Code 1", "Cost Code 2", "Cost Code 3", "Program Code",
+        ]);
+
+        function monthSorter(a, b) {
+            const parse = v => (v === "" || v == null) ? -Infinity : parseFloat(v);
+            return parse(a) - parse(b);
+        }
+
+        function isPastMonth(name) {
+            if (!monthPattern.test(name)) return false;
+            const d = new Date(name + " 1");
+            const now = new Date();
+            return d.getFullYear() < now.getFullYear() ||
+                   (d.getFullYear() === now.getFullYear() && d.getMonth() < now.getMonth());
+        }
+
+        let showAllRows = false;
+
+        function applyRowFilter(table) {
+            if (showAllRows) {
+                table.clearFilter(true);
+                return;
+            }
+            const visibleMonthFields = table.getColumns()
+                .filter(c => c.isVisible() && monthPattern.test(c.getField()))
+                .map(c => c.getField());
+            if (visibleMonthFields.length === 0) {
+                table.clearFilter(true);
+                return;
+            }
+            table.setFilter(row => visibleMonthFields.some(f => row[f] !== "" && row[f] != null));
+        }
+
+        fetch("/api/data")
+            .then(r => r.json())
+            .then(({columns, data}) => {
+                const colDefs = columns.map(name => ({
+                    title: name,
+                    field: name,
+                    headerFilter: "input",
+                    sorter: monthPattern.test(name) ? monthSorter : "string",
+                    visible: !hiddenByDefault.has(name) && !isPastMonth(name),
+                }));
+
+                const table = new Tabulator("#table", {
+                    data: data,
+                    columns: colDefs,
+                    layout: "fitDataFill",
+                    height: "85vh",
+                    initialSort: [
+                        {column: "Group", dir: "asc"},
+                        {column: "Employee", dir: "asc"},
+                    ],
+                });
+
+                const btn = document.getElementById("col-btn");
+                const dropdown = document.getElementById("col-dropdown");
+                const showAllBtn = document.getElementById("show-all-btn");
+
+                table.on("tableBuilt", () => {
+                    applyRowFilter(table);
+
+                    table.getColumns().forEach(col => {
+                        const label = document.createElement("label");
+                        const cb = document.createElement("input");
+                        cb.type = "checkbox";
+                        cb.checked = col.isVisible();
+                        cb.addEventListener("change", () => col.toggle());
+                        label.appendChild(cb);
+                        label.appendChild(document.createTextNode("\u00a0" + col.getDefinition().title));
+                        dropdown.appendChild(label);
+                    });
+                });
+
+                table.on("columnVisibilityChanged", () => applyRowFilter(table));
+
+                showAllBtn.addEventListener("click", () => {
+                    showAllRows = !showAllRows;
+                    showAllBtn.classList.toggle("active", showAllRows);
+                    applyRowFilter(table);
+                });
+
+                btn.addEventListener("click", e => {
+                    e.stopPropagation();
+                    dropdown.classList.toggle("open");
+                });
+
+                dropdown.addEventListener("click", e => e.stopPropagation());
+                document.addEventListener("click", () => dropdown.classList.remove("open"));
+            });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Replace static HTML table with Tabulator for interactive sorting, filtering, and column toggling; columns stay open while checking multiple boxes
- Add `sej-load` CLI command replacing the previous manual Python invocation
- Skip zero-percent effort values on import (treated same as blank cells)
- Treat N/A project names as the Non-Project sentinel value
- Hide past month columns by default; hide rows with no effort in any visible month column, with a "Show all rows" toggle