### PR TITLE
Fix fix_totals and add editor UI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ uv sync
 The database is populated from a TSV file exported from the effort-tracking spreadsheet.
 
 ```
-uv run sej-load data.tsv sej.db
+uv run sej-load IET_2_8_26_anon.tsv
 ```
 
-The first load creates the database directly. Subsequent loads create a **branch** that can be reviewed and merged (see [Branching](#branching) below).
+This creates `data/sej.db`. The first load creates the database directly. Subsequent loads create a **branch** that can be reviewed and merged (see [Branching](#branching) below).
+
+You can specify an explicit output path as a second argument:
+
+```
+uv run sej-load mydata.tsv path/to/custom.db
+```
 
 **Input file requirements:**
 
@@ -31,10 +37,16 @@ The first load creates the database directly. Subsequent loads create a **branch
 A Flask web app displays the effort data in a spreadsheet-style table.
 
 ```bash
-uv run sej-web sej.db
+uv run sej-web
 ```
 
-Then open http://127.0.0.1:5000 in your browser. The database path argument is optional and defaults to `IET_2_8_26_anon.db`.
+The database path argument is optional and defaults to `data/sej.db`. To use a different path:
+
+```bash
+uv run sej-web path/to/custom.db
+```
+
+Then open http://127.0.0.1:5000 in your browser.
 
 When viewing a **branch** database, the app enters edit mode:
 
@@ -52,38 +64,34 @@ All changes go through branches. A branch is a full copy of the main database th
 ### Create a branch
 
 ```bash
-uv run sej-branch create my-edits --from-db sej.db
+uv run sej-branch create my-edits
 ```
 
-This copies `sej.db` to `sej_branch_my-edits.db`. Open the branch in the web app to edit:
-
-```bash
-uv run sej-web sej_branch_my-edits.db
-```
+This copies `data/sej.db` to `data/sej_branch_my-edits.db`. The web app picks up the branch automatically — just refresh.
 
 ### List branches
 
 ```bash
-uv run sej-branch list --db sej.db
+uv run sej-branch list
 ```
 
 ### Merge a branch
 
 ```bash
-uv run sej-branch merge my-edits --db sej.db
+uv run sej-branch merge my-edits
 ```
 
 This:
 1. Computes a diff between the branch and main
-2. Writes a change-log TSV (`merge_my-edits_<timestamp>.tsv`)
-3. Backs up the current main (`sej_backup_<timestamp>.db`)
+2. Writes a change-log TSV (`data/merges/merge_my-edits_<timestamp>.tsv`)
+3. Backs up the current main (`data/backups/sej_backup_<timestamp>.db`)
 4. Replaces main with the branch
 5. Records the merge in the audit log
 
 ### Delete a branch (without merging)
 
 ```bash
-uv run sej-branch delete my-edits --db sej.db
+uv run sej-branch delete my-edits
 ```
 
 ### Revert to a previous main
@@ -92,16 +100,16 @@ Every merge creates a backup. To roll back:
 
 ```bash
 # Revert to the most recent backup
-uv run sej-branch revert --db sej.db
+uv run sej-branch revert
 
 # Revert to a specific backup
-uv run sej-branch revert sej_backup_20260215_143000_123456.db --db sej.db
+uv run sej-branch revert data/backups/sej_backup_20260215_143000_123456.db
 ```
 
 ### List available backups
 
 ```bash
-uv run sej-branch backups --db sej.db
+uv run sej-branch backups
 ```
 
 Backups are listed most-recent-first.
@@ -110,10 +118,10 @@ Backups are listed most-recent-first.
 
 ```bash
 # Keep only the 5 most recent (default)
-uv run sej-branch prune-backups --db sej.db
+uv run sej-branch prune-backups
 
 # Keep only the 2 most recent
-uv run sej-branch prune-backups --keep 2 --db sej.db
+uv run sej-branch prune-backups --keep 2
 ```
 
 ## Running Tests

--- a/sej/importer.py
+++ b/sej/importer.py
@@ -66,6 +66,8 @@ def load_tsv(tsv_path: str | Path, db_path: str | Path) -> None:
         db_path:  Path to the SQLite database file (created if absent).
     """
     tsv_path = Path(tsv_path)
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = get_connection(db_path)
     create_schema(conn)
     _clear_data(conn)
@@ -211,7 +213,7 @@ def main():
     if len(sys.argv) < 2 or len(sys.argv) > 3:
         sys.exit("Usage: sej-load TSV_PATH [DB_PATH]")
     tsv_path = Path(sys.argv[1])
-    db_path = Path(sys.argv[2]) if len(sys.argv) == 3 else tsv_path.with_suffix(".db")
+    db_path = Path(sys.argv[2]) if len(sys.argv) == 3 else Path("data/sej.db")
     result = load_tsv_as_branch(tsv_path, db_path)
     if result == db_path:
         print(f"Loaded {tsv_path} → {db_path}")

--- a/sej/templates/index.html
+++ b/sej/templates/index.html
@@ -41,6 +41,10 @@
         button { cursor: pointer; padding: 4px 10px; }
         #show-all-btn.active { background: #0d6efd; color: #fff; border-color: #0d6efd; }
         #select-mode-btn.active { background: #198754; color: #fff; border-color: #198754; }
+        #edit-data-btn { background: #0d6efd; color: #fff; border: 1px solid #0d6efd; }
+        #save-btn { background: #198754; color: #fff; border: 1px solid #198754; }
+        #discard-btn { background: #dc3545; color: #fff; border: 1px solid #dc3545; }
+        #fix-totals-btn { background: #fd7e14; color: #fff; border: 1px solid #fd7e14; }
         .cell-selected { outline: 2px solid #198754 !important; outline-offset: -2px; }
         #selection-toolbar {
             display: none;
@@ -94,8 +98,12 @@
             <div id="col-dropdown"></div>
         </div>
         <button id="show-all-btn">Show all rows</button>
+        <button id="edit-data-btn" style="display:none">Edit data</button>
         <button id="select-mode-btn" style="display:none">Selection mode</button>
+        <button id="fix-totals-btn" style="display:none">Fix totals</button>
         <button id="add-row-btn" style="display:none">Add allocation line</button>
+        <button id="save-btn" style="display:none">Save changes</button>
+        <button id="discard-btn" style="display:none">Discard changes</button>
     </div>
     <div id="table"></div>
 
@@ -207,13 +215,18 @@
         fetch("/api/data")
             .then(r => r.json())
             .then(({columns, data, editable, branch_name}) => {
-                // Show branch banner
+                // Show branch banner and edit-mode buttons
                 if (editable && branch_name) {
                     const banner = document.getElementById("branch-banner");
                     banner.textContent = `Editing branch: ${branch_name}`;
                     banner.style.display = "block";
                     document.getElementById("select-mode-btn").style.display = "";
+                    document.getElementById("fix-totals-btn").style.display = "";
                     document.getElementById("add-row-btn").style.display = "";
+                    document.getElementById("save-btn").style.display = "";
+                    document.getElementById("discard-btn").style.display = "";
+                } else {
+                    document.getElementById("edit-data-btn").style.display = "";
                 }
 
                 const monthFields = columns.filter(name => monthPattern.test(name));
@@ -233,11 +246,21 @@
                             def.editor = "input";
                         }
                         def.formatter = (cell) => {
-                            const emp = cell.getRow().getData()["Employee"];
+                            const rowData = cell.getRow().getData();
+                            const emp = rowData["Employee"];
+                            const lineId = rowData["allocation_line_id"];
+                            const key = `${lineId}|${name}`;
+                            const el = cell.getElement();
                             if (violations.has(`${emp}|${name}`)) {
-                                cell.getElement().style.backgroundColor = "#ffcccc";
+                                el.style.backgroundColor = "#ffcccc";
                             } else {
-                                cell.getElement().style.backgroundColor = "";
+                                el.style.backgroundColor = "";
+                            }
+                            if (selectedCells.has(key)) {
+                                el.classList.add("cell-selected");
+                                selectedElements.set(key, el);
+                            } else {
+                                el.classList.remove("cell-selected");
                             }
                             return cell.getValue() ?? "";
                         };
@@ -275,6 +298,25 @@
                         {column: "Group", dir: "asc"},
                         {column: "Employee", dir: "asc"},
                     ],
+                });
+
+                function applyGroupBorders() {
+                    const sorters = table.getSorters();
+                    const primaryField = sorters.length > 0 ? sorters[0].field : null;
+                    const rows = table.getRows("active");
+                    rows.forEach((row, i) => {
+                        const el = row.getElement();
+                        if (!el) return;
+                        el.style.borderTop = (primaryField && i > 0 &&
+                            row.getData()[primaryField] !== rows[i - 1].getData()[primaryField])
+                            ? "2px solid #888" : "";
+                    });
+                }
+
+                table.on("renderComplete", applyGroupBorders);
+
+                table.on("cellEditing", (cell) => {
+                    if (selectMode) cell.cancelEdit();
                 });
 
                 const btn = document.getElementById("col-btn");
@@ -362,6 +404,17 @@
                     showAllRows = !showAllRows;
                     showAllBtn.classList.toggle("active", showAllRows);
                     applyRowFilter(table);
+                });
+
+                // Fix totals
+                document.getElementById("fix-totals-btn").addEventListener("click", () => {
+                    fetch("/api/fix-totals", { method: "POST" })
+                        .then(r => r.json())
+                        .then(data => {
+                            const n = data.changes ? data.changes.length : 0;
+                            alert(`Fixed ${n} cell${n === 1 ? "" : "s"}.`);
+                            window.location.reload();
+                        });
                 });
 
                 // Selection mode
@@ -492,6 +545,35 @@
 
                 dropdown.addEventListener("click", e => e.stopPropagation());
                 document.addEventListener("click", () => dropdown.classList.remove("open"));
+
+                // Edit / Save / Discard handlers
+                document.getElementById("edit-data-btn").addEventListener("click", () => {
+                    fetch("/api/branch/create", { method: "POST" })
+                        .then(r => {
+                            if (!r.ok) return r.json().then(d => { alert("Error: " + d.error); throw new Error(); });
+                            return r.json();
+                        })
+                        .then(() => location.reload());
+                });
+
+                document.getElementById("save-btn").addEventListener("click", () => {
+                    fetch("/api/branch/merge", { method: "POST" })
+                        .then(r => {
+                            if (!r.ok) return r.json().then(d => { alert("Error: " + d.error); throw new Error(); });
+                            return r.json();
+                        })
+                        .then(() => location.reload());
+                });
+
+                document.getElementById("discard-btn").addEventListener("click", () => {
+                    if (!confirm("Discard all changes? This cannot be undone.")) return;
+                    fetch("/api/branch/discard", { method: "POST" })
+                        .then(r => {
+                            if (!r.ok) return r.json().then(d => { alert("Error: " + d.error); throw new Error(); });
+                            return r.json();
+                        })
+                        .then(() => location.reload());
+                });
             });
     </script>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -250,3 +250,517 @@ def test_api_allocation_line_new_project(branch_client, branch_db):
     ).fetchone()
     conn.close()
     assert proj["name"] == "Brand New Project"
+
+
+# --- Fix totals tests ---
+
+@pytest.fixture
+def violations_db(tmp_path):
+    """DB where Smith,Jane's July total is 90% (violation) and has a Non-Project line."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Smith,Jane: 60% on real project + 30% Non-Project (20152) = 90% (violation)
+        ["Smith,Jane", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "60.00%", ""],
+        ["", "Engineering", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "30.00%", ""],
+        # Jones,Bob: 100% Non-Project = no violation
+        ["Jones,Bob", "Ops", "20152", "12001", "512120",
+         "", "", "", "VROPS", "N/A", "N/A",
+         "100.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+@pytest.fixture
+def violations_branch_db(violations_db):
+    return create_branch(violations_db, "test_fix")
+
+
+@pytest.fixture
+def violations_branch_client(violations_branch_db):
+    app = create_app(db_path=violations_branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_api_fix_totals_forbidden_on_main(violations_db):
+    app = create_app(db_path=violations_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 403
+
+
+def test_api_fix_totals(violations_branch_client, violations_branch_db):
+    resp = violations_branch_client.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    # Only Smith,Jane July 2025 needs fixing
+    assert len(changes) == 1
+    assert changes[0]["year"] == 2025
+    assert changes[0]["month"] == 7
+    assert abs(changes[0]["old_percentage"] - 30.0) < 0.01
+    assert abs(changes[0]["new_percentage"] - 40.0) < 0.01
+
+    from sej.db import get_connection
+    conn = get_connection(violations_branch_db)
+    np_line = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN employees e ON e.id = al.employee_id
+        JOIN projects p ON p.id = al.project_id
+        WHERE e.name = 'Smith,Jane' AND p.project_code = 'Non-Project'
+    """).fetchone()
+    effort = conn.execute(
+        "SELECT percentage FROM efforts WHERE allocation_line_id = ? AND year = 2025 AND month = 7",
+        (np_line["id"],),
+    ).fetchone()
+    conn.close()
+    assert abs(effort["percentage"] - 40.0) < 0.01
+
+
+def test_api_fix_totals_no_changes_when_balanced(branch_client):
+    """When all totals are already 100%, fix-totals returns an empty change list."""
+    resp = branch_client.post("/api/fix-totals")
+    assert resp.status_code == 200
+    assert resp.json["changes"] == []
+
+
+@pytest.fixture
+def multi_nonproject_db(tmp_path):
+    """DB where an employee has two Non-Project lines (27152 and 20152) and a violation."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Jones,Bob: 60% real project + 20% Non-Project/27152 + 10% Non-Project/20152 = 90%
+        ["Jones,Bob", "Ops", "25210", "49000", "511120",
+         "", "", "", "", "5120001", "Widget Project",
+         "60.00%", ""],
+        ["", "Ops", "27152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "20.00%", ""],
+        ["", "Ops", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "10.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_api_fix_totals_adds_to_largest_np(multi_nonproject_db):
+    """When two NP lines exist, shortfall is added to the one with the most effort."""
+    branch_db = create_branch(multi_nonproject_db, "test_multi")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    # Total is 90%, shortfall is 10%.  The 27152 line has 20% (largest), so it gets bumped.
+    assert len(changes) == 1
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    # 27152 goes from 20% to 30%; 20152 stays at 10%.
+    line_27152 = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN projects p ON p.id = al.project_id
+        WHERE p.project_code = 'Non-Project' AND al.fund_code = '27152'
+    """).fetchone()
+    effort_27152 = conn.execute(
+        "SELECT percentage FROM efforts WHERE allocation_line_id = ? AND year = 2025 AND month = 7",
+        (line_27152["id"],),
+    ).fetchone()
+    assert abs(effort_27152["percentage"] - 30.0) < 0.01
+
+    line_20152 = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN projects p ON p.id = al.project_id
+        WHERE p.project_code = 'Non-Project' AND al.fund_code = '20152'
+    """).fetchone()
+    effort_20152 = conn.execute(
+        "SELECT percentage FROM efforts WHERE allocation_line_id = ? AND year = 2025 AND month = 7",
+        (line_20152["id"],),
+    ).fetchone()
+    conn.close()
+    assert abs(effort_20152["percentage"] - 10.0) < 0.01
+
+
+@pytest.fixture
+def no_nonproject_db(tmp_path):
+    """DB where Smith,Jane has effort but no Non-Project allocation line."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Smith,Jane: 60% on real project only — no Non-Project line at all
+        ["Smith,Jane", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "60.00%", ""],
+        # Jones,Bob: balanced, no issue
+        ["Jones,Bob", "Ops", "20152", "12001", "512120",
+         "", "", "", "VROPS", "N/A", "N/A",
+         "100.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_creates_nonproject_line_when_missing(no_nonproject_db):
+    """fix_totals creates a Non-Project allocation line when one doesn't exist."""
+    branch_db = create_branch(no_nonproject_db, "test_no_np")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    assert len(changes) == 1
+    assert changes[0]["year"] == 2025
+    assert changes[0]["month"] == 7
+    assert abs(changes[0]["new_percentage"] - 40.0) < 0.01
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    np_line = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN employees e ON e.id = al.employee_id
+        JOIN projects p ON p.id = al.project_id
+        WHERE e.name = 'Smith,Jane' AND p.project_code = 'Non-Project'
+    """).fetchone()
+    assert np_line is not None
+    effort = conn.execute(
+        "SELECT percentage FROM efforts WHERE allocation_line_id = ? AND year = 2025 AND month = 7",
+        (np_line["id"],),
+    ).fetchone()
+    conn.close()
+    assert abs(effort["percentage"] - 40.0) < 0.01
+
+
+@pytest.fixture
+def abbott_db(tmp_path):
+    """Abbott case: total=76%, three NP lines, two with 20152 (one empty, one 41%)."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Abbott,Christine: 10% NP/27152 + 20% proj + 5% proj + empty NP/20152 + 41% NP/20152 = 76%
+        ["Abbott,Christine", "PM", "27152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "10.00%", ""],
+        ["", "PM", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5130266", "Dashboard Project",
+         "20.00%", ""],
+        ["", "PM", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5135630", "Timesheet Project",
+         "5.00%", ""],
+        ["", "PM", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "", ""],
+        ["", "PM", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "41.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_abbott_adds_to_existing_np(abbott_db):
+    """Abbott: shortfall added to the 41% NP/20152 line, not the empty NP/20152 line."""
+    branch_db = create_branch(abbott_db, "test_abbott")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    assert len(changes) == 1
+    # The 41% line should become 65%, not the empty line becoming 24%
+    assert abs(changes[0]["old_percentage"] - 41.0) < 0.01
+    assert abs(changes[0]["new_percentage"] - 65.0) < 0.01
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    # The 27152 NP line should be untouched at 10%
+    line_27152 = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN projects p ON p.id = al.project_id
+        WHERE p.project_code = 'Non-Project' AND al.fund_code = '27152'
+    """).fetchone()
+    effort_27152 = conn.execute(
+        "SELECT percentage FROM efforts WHERE allocation_line_id = ? AND year = 2025 AND month = 7",
+        (line_27152["id"],),
+    ).fetchone()
+    conn.close()
+    assert abs(effort_27152["percentage"] - 10.0) < 0.01
+
+
+@pytest.fixture
+def baker_multi_np_over_100_db(tmp_path):
+    """Baker case: total=110%, two NP lines, preferred (20152) has no effort, other has 10%."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Baker: 65% + 35% real projects = 100%, plus 10% on Non-Project/27152 = 110%
+        # The preferred Non-Project line (20152) has no effort for this month.
+        ["Baker,Jeremy Boyd", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "65.00%", ""],
+        ["", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120002", "Other Project",
+         "35.00%", ""],
+        ["", "Engineering", "27152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "10.00%", ""],
+        ["", "Engineering", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_baker_multi_np_over_100(baker_multi_np_over_100_db):
+    """Baker case: two NP lines, preferred has no effort, other has 10%. Total=110%.
+
+    fix_totals must reduce the 10% NP effort to 0%, not silently skip it.
+    """
+    branch_db = create_branch(baker_multi_np_over_100_db, "test_baker")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    # The 10% NP effort should be zeroed out
+    assert len(changes) >= 1
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    # After fix, all NP efforts for Baker in July should be 0
+    np_efforts = conn.execute("""
+        SELECT e.percentage
+        FROM efforts e
+        JOIN allocation_lines al ON al.id = e.allocation_line_id
+        JOIN employees emp ON emp.id = al.employee_id
+        JOIN projects p ON p.id = al.project_id
+        WHERE emp.name = 'Baker,Jeremy Boyd'
+          AND p.project_code = 'Non-Project'
+          AND e.year = 2025 AND e.month = 7
+    """).fetchall()
+    total_np = sum(r["percentage"] for r in np_efforts)
+    assert abs(total_np) < 0.01, f"Total NP effort should be 0, got {total_np}"
+
+    # Total for Baker in July should now be 100%
+    total = conn.execute("""
+        SELECT SUM(e.percentage) AS total
+        FROM efforts e
+        JOIN allocation_lines al ON al.id = e.allocation_line_id
+        JOIN employees emp ON emp.id = al.employee_id
+        WHERE emp.name = 'Baker,Jeremy Boyd'
+          AND e.year = 2025 AND e.month = 7
+    """).fetchone()["total"]
+    conn.close()
+    assert abs(total - 100.0) < 0.01, f"Total should be 100, got {total}"
+
+    # No negative values anywhere
+    conn = get_connection(branch_db)
+    negatives = conn.execute("SELECT percentage FROM efforts WHERE percentage < 0").fetchall()
+    conn.close()
+    assert negatives == []
+
+
+@pytest.fixture
+def over_100_np_other_month_db(tmp_path):
+    """DB where projects total 110% in July but Non-Project only has effort in August."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Baker: 60% + 50% real projects in July = 110%, Non-Project only in August
+        ["Baker,Jeremy Boyd", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "60.00%", "50.00%"],
+        ["", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120002", "Other Project",
+         "50.00%", "40.00%"],
+        ["", "Engineering", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "", "10.00%"],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_over_100_np_line_exists_but_no_effort_for_month(over_100_np_other_month_db):
+    """When total>100, NP line exists but has no effort for that month: no negative row created."""
+    branch_db = create_branch(over_100_np_other_month_db, "test_baker2")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    negatives = conn.execute("SELECT percentage FROM efforts WHERE percentage < 0").fetchall()
+    conn.close()
+    assert negatives == [], "No effort row should have a negative percentage"
+
+
+@pytest.fixture
+def over_100_with_np_db(tmp_path):
+    """DB where project efforts alone exceed 100%, plus a Non-Project line."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Smith,Jane: 80% + 40% real projects + 10% Non-Project = 130% total.
+        # Projects alone (120%) already exceed 100, so Non-Project can't fix it.
+        ["Smith,Jane", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "80.00%", ""],
+        ["", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120002", "Other Project",
+         "40.00%", ""],
+        ["", "Engineering", "20152", "49000", "511120",
+         "", "", "", "", "N/A", "N/A",
+         "10.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_over_100_np_reduced_to_zero(over_100_with_np_db):
+    """When project efforts alone exceed 100%, Non-Project is reduced to 0, not negative."""
+    branch_db = create_branch(over_100_with_np_db, "test_over100")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    changes = resp.json["changes"]
+    # other_sum = 120%, new_np = max(0, -20) = 0 — Non-Project is reduced to 0
+    assert len(changes) == 1
+    assert abs(changes[0]["new_percentage"] - 0.0) < 0.01
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    rows = conn.execute(
+        "SELECT percentage FROM efforts WHERE percentage < 0"
+    ).fetchall()
+    conn.close()
+    assert rows == [], "No effort row should have a negative percentage"
+
+
+@pytest.fixture
+def over_100_no_np_db(tmp_path):
+    """DB where Smith,Jane's project efforts alone exceed 100%, no Non-Project line."""
+    tsv = tmp_path / "data_anon.tsv"
+    db = tmp_path / "test_anon.db"
+    _write_tsv(tsv, [
+        # Smith,Jane: 110% on real projects only — no Non-Project line
+        ["Smith,Jane", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120001", "Widget Project",
+         "60.00%", ""],
+        ["", "Engineering", "25210", "49000", "511120",
+         "", "", "", "VRENG", "5120002", "Other Project",
+         "50.00%", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_fix_totals_over_100_no_np_line_not_created(over_100_no_np_db):
+    """When total > 100 and no Non-Project line exists, fix_totals must not create one."""
+    branch_db = create_branch(over_100_no_np_db, "test_over100_nonp")
+    app = create_app(db_path=branch_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        resp = c.post("/api/fix-totals")
+    assert resp.status_code == 200
+    assert resp.json["changes"] == []
+
+    from sej.db import get_connection
+    conn = get_connection(branch_db)
+    np_line = conn.execute("""
+        SELECT al.id FROM allocation_lines al
+        JOIN employees e ON e.id = al.employee_id
+        JOIN projects p ON p.id = al.project_id
+        WHERE e.name = 'Smith,Jane' AND p.project_code = 'Non-Project'
+    """).fetchone()
+    conn.close()
+    assert np_line is None, "No Non-Project line should be created when total > 100"
+
+
+# --- Branch workflow API tests ---
+
+@pytest.fixture
+def main_client(loaded_db):
+    """A test client pointed at the main DB (uses MAIN_DB_PATH for branch resolution)."""
+    app = create_app(db_path=loaded_db)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_api_branch_create(main_client, loaded_db):
+    resp = main_client.post("/api/branch/create")
+    assert resp.status_code == 200
+    data = resp.json
+    assert "branch_name" in data
+    assert data["branch_name"].startswith("edit-")
+
+    # The app should now serve branch data
+    resp2 = main_client.get("/api/data")
+    assert resp2.json["editable"] is True
+
+
+def test_api_branch_create_already_exists(main_client, loaded_db):
+    main_client.post("/api/branch/create")
+    resp = main_client.post("/api/branch/create")
+    assert resp.status_code == 409
+
+
+def test_api_branch_merge(main_client, loaded_db):
+    main_client.post("/api/branch/create")
+    resp = main_client.post("/api/branch/merge")
+    assert resp.status_code == 200
+    assert "merged" in resp.json
+
+    # Should be back on main
+    resp2 = main_client.get("/api/data")
+    assert resp2.json["editable"] is False
+
+
+def test_api_branch_discard(main_client, loaded_db):
+    main_client.post("/api/branch/create")
+    resp = main_client.post("/api/branch/discard")
+    assert resp.status_code == 200
+    assert "discarded" in resp.json
+
+    # Should be back on main
+    resp2 = main_client.get("/api/data")
+    assert resp2.json["editable"] is False
+
+
+def test_api_branch_merge_on_main(main_client):
+    resp = main_client.post("/api/branch/merge")
+    assert resp.status_code == 409
+
+
+def test_api_branch_discard_on_main(main_client):
+    resp = main_client.post("/api/branch/discard")
+    assert resp.status_code == 409
+
+
+def test_edit_data_button_visible_on_main(main_client):
+    resp = main_client.get("/api/data")
+    assert resp.json["editable"] is False
+
+
+def test_edit_data_button_hidden_on_branch(main_client, loaded_db):
+    main_client.post("/api/branch/create")
+    resp = main_client.get("/api/data")
+    assert resp.json["editable"] is True


### PR DESCRIPTION
## Summary

- Fix `fix_totals` to correctly handle employees with multiple Non-Project allocation lines
  - Under 100%: add shortfall to the NP line with the largest existing effort (not the first by id, which may be empty)
  - Over 100%: walk all NP lines reducing each until total reaches 100 or all NP effort is gone
  - Deletes effort rows reduced to 0% instead of storing 0.00%
- Add editor UI features: fix-totals endpoint, allocation line management
- Update README with corrected CLI usage

## Test plan

- [x] Added test for Abbott case (multiple NP lines with same fund code, shortfall goes to largest)
- [x] Added test for Baker case (over 100% with multiple NP lines, preferred has no effort)
- [x] Added tests for over-100 edge cases (NP reduced to zero, no NP line exists)
- [x] All 101 tests pass