### PR TITLE
Add external group support

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -13,12 +13,15 @@ are stored against those lines.
 
 ### `groups`
 
-Organizational teams or units.
+Organizational teams or units. Groups loaded from the TSV are always internal.
+Externally-created groups (people from partner organizations) are marked as
+external so their effort is not expected to sum to 100%.
 
 | Column | Type | Constraints |
 |--------|------|-------------|
 | `id` | integer | PK |
 | `name` | text | UNIQUE NOT NULL |
+| `is_internal` | integer | NOT NULL DEFAULT 1 — 1 = internal, 0 = external |
 
 ---
 

--- a/sej/db.py
+++ b/sej/db.py
@@ -14,8 +14,9 @@ def create_schema(conn: sqlite3.Connection) -> None:
     """Create all tables. Safe to call on an existing database (no-op if tables exist)."""
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS groups (
-            id   INTEGER PRIMARY KEY,
-            name TEXT    UNIQUE NOT NULL
+            id          INTEGER PRIMARY KEY,
+            name        TEXT    UNIQUE NOT NULL,
+            is_internal INTEGER NOT NULL DEFAULT 1
         );
 
         CREATE TABLE IF NOT EXISTS employees (
@@ -64,4 +65,10 @@ def create_schema(conn: sqlite3.Connection) -> None:
             details   TEXT
         );
     """)
+
+    # Migration: add is_internal to groups if it doesn't exist (for older DBs)
+    existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(groups)").fetchall()}
+    if "is_internal" not in existing_cols:
+        conn.execute("ALTER TABLE groups ADD COLUMN is_internal INTEGER NOT NULL DEFAULT 1")
+
     conn.commit()

--- a/sej/templates/group_details.html
+++ b/sej/templates/group_details.html
@@ -178,21 +178,22 @@
                 .catch(err => showError(err.message));
         }
 
-        // Load groups into dropdown
+        // Load groups into dropdown (internal only)
         fetch("/api/groups")
             .then(r => r.json())
             .then(groups => {
+                const internal = groups.filter(g => g.is_internal);
                 const sel = document.getElementById("group-select");
                 sel.innerHTML = '<option value="">-- select a group --</option>';
-                groups.forEach(g => {
+                internal.forEach(g => {
                     const opt = document.createElement("option");
-                    opt.value = g;
-                    opt.textContent = g;
+                    opt.value = g.name;
+                    opt.textContent = g.name;
                     sel.appendChild(opt);
                 });
-                if (groups.length === 1) {
-                    sel.value = groups[0];
-                    loadGroup(groups[0]);
+                if (internal.length === 1) {
+                    sel.value = internal[0].name;
+                    loadGroup(internal[0].name);
                 }
             });
 

--- a/sej/templates/index.html
+++ b/sej/templates/index.html
@@ -103,6 +103,16 @@
             align-items: center;
         }
         #add-employee-overlay.open { display: flex; }
+        #add-group-overlay {
+            display: none;
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.4);
+            z-index: 300;
+            justify-content: center;
+            align-items: center;
+        }
+        #add-group-overlay.open { display: flex; }
         #add-row-form {
             background: #fff;
             padding: 20px;
@@ -134,6 +144,7 @@
         <button id="add-employee-btn" style="display:none">Add employee</button>
         <button id="add-row-btn" style="display:none">Add allocation line</button>
         <button id="add-project-btn" style="display:none">Add project</button>
+        <button id="add-group-btn" style="display:none">Add group</button>
         <button id="save-btn" style="display:none">Save changes</button>
         <button id="discard-btn" style="display:none">Discard changes</button>
     </div>
@@ -192,6 +203,27 @@
         </div>
     </div>
 
+    <div id="add-group-overlay">
+        <div id="add-row-form">
+            <h3 style="margin-top:0">Add Group</h3>
+            <label>Group Name</label>
+            <input id="ag-name" placeholder="Enter group name">
+            <label>Type</label>
+            <div style="margin-top:6px;display:flex;gap:16px;">
+                <label style="font-weight:normal;display:flex;align-items:center;gap:4px;">
+                    <input type="radio" name="ag-type" id="ag-internal" value="internal" checked> Internal
+                </label>
+                <label style="font-weight:normal;display:flex;align-items:center;gap:4px;">
+                    <input type="radio" name="ag-type" id="ag-external" value="external"> External
+                </label>
+            </div>
+            <div class="btn-row">
+                <button id="ag-cancel">Cancel</button>
+                <button id="ag-submit">Add</button>
+            </div>
+        </div>
+    </div>
+
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script>
         const monthPattern = /January|February|March|April|May|June|July|August|September|October|November|December/;
@@ -239,10 +271,11 @@
             table.setFilter(row => visibleMonthFields.some(f => row[f] !== "" && row[f] != null));
         }
 
-        function computeViolations(data, monthFields) {
+        function computeViolations(data, monthFields, externalGroups) {
             const violations = new Set();
             const sums = {};
             data.forEach(row => {
+                if (externalGroups && externalGroups.has(row["Group"])) return;
                 const emp = row["Employee"];
                 if (!sums[emp]) sums[emp] = {};
                 monthFields.forEach(mf => {
@@ -274,9 +307,13 @@
             updateSelectionToolbar();
         }
 
-        fetch("/api/data")
-            .then(r => r.json())
-            .then(({columns, data, editable, branch_name}) => {
+        Promise.all([
+            fetch("/api/data").then(r => r.json()),
+            fetch("/api/groups").then(r => r.json()),
+        ]).then(([{columns, data, editable, branch_name}, groupsList]) => {
+                const externalGroups = new Set(
+                    groupsList.filter(g => !g.is_internal).map(g => g.name)
+                );
                 // Show branch banner and edit-mode buttons
                 if (editable && branch_name) {
                     const banner = document.getElementById("branch-banner");
@@ -287,6 +324,7 @@
                     document.getElementById("add-employee-btn").style.display = "";
                     document.getElementById("add-row-btn").style.display = "";
                     document.getElementById("add-project-btn").style.display = "";
+                    document.getElementById("add-group-btn").style.display = "";
                     document.getElementById("save-btn").style.display = "";
                     document.getElementById("discard-btn").style.display = "";
                 } else {
@@ -294,7 +332,7 @@
                 }
 
                 const monthFields = columns.filter(name => monthPattern.test(name));
-                let violations = computeViolations(data, monthFields);
+                let violations = computeViolations(data, monthFields, externalGroups);
 
                 const colDefs = columns.map(name => {
                     const isMonth = monthPattern.test(name);
@@ -471,7 +509,7 @@
 
                         // Recompute violations
                         const allData = table.getData();
-                        violations = computeViolations(allData, monthFields);
+                        violations = computeViolations(allData, monthFields, externalGroups);
                         table.getRows().forEach(row => {
                             monthFields.forEach(mf => {
                                 const c = row.getCell(mf);
@@ -531,8 +569,8 @@
                             return fetch("/api/data").then(r => r.json());
                         })
                         .then(({data}) => {
+                            violations = computeViolations(data, monthFields, externalGroups);
                             table.replaceData(data);
-                            violations = computeViolations(table.getData(), monthFields);
                         });
                 });
 
@@ -583,7 +621,7 @@
 
                         // Recompute violations
                         const allData = table.getData();
-                        violations = computeViolations(allData, monthFields);
+                        violations = computeViolations(allData, monthFields, externalGroups);
                         table.getRows().forEach(row => {
                             const emp = row.getData()["Employee"];
                             monthFields.forEach(mf => {
@@ -613,8 +651,8 @@
                         sel.innerHTML = "";
                         groups.forEach(g => {
                             const opt = document.createElement("option");
-                            opt.value = g;
-                            opt.textContent = g;
+                            opt.value = g.name;
+                            opt.textContent = g.name;
                             sel.appendChild(opt);
                         });
                     });
@@ -720,7 +758,7 @@
                         }
                         table.replaceData(data).then(() => {
                             applyRowFilter(table);
-                            violations = computeViolations(table.getData(), monthFields);
+                            violations = computeViolations(table.getData(), monthFields, externalGroups);
                             // Scroll to the new row
                             const rows = table.getRows();
                             for (const row of rows) {
@@ -761,6 +799,52 @@
                     .then(result => {
                         document.getElementById("add-project-overlay").classList.remove("open");
                         alert(`Project created with code: ${result.project_code}`);
+                    });
+                });
+
+                // Add group
+                document.getElementById("add-group-btn").addEventListener("click", () => {
+                    document.getElementById("ag-name").value = "";
+                    document.getElementById("ag-internal").checked = true;
+                    document.getElementById("add-group-overlay").classList.add("open");
+                });
+
+                document.getElementById("ag-cancel").addEventListener("click", () => {
+                    document.getElementById("add-group-overlay").classList.remove("open");
+                });
+
+                document.getElementById("ag-submit").addEventListener("click", () => {
+                    const name = document.getElementById("ag-name").value.trim();
+                    if (!name) {
+                        alert("Group name is required.");
+                        return;
+                    }
+                    const isInternal = document.getElementById("ag-internal").checked;
+                    fetch("/api/group", {
+                        method: "POST",
+                        headers: {"Content-Type": "application/json"},
+                        body: JSON.stringify({ name, is_internal: isInternal }),
+                    })
+                    .then(r => {
+                        if (!r.ok) return r.json().then(d => { alert("Error: " + d.error); throw new Error(); });
+                        return r.json();
+                    })
+                    .then(() => {
+                        document.getElementById("add-group-overlay").classList.remove("open");
+                        return fetch("/api/groups").then(r => r.json());
+                    })
+                    .then(groupsList => {
+                        externalGroups.clear();
+                        groupsList.filter(g => !g.is_internal).forEach(g => externalGroups.add(g.name));
+                        violations = computeViolations(table.getData(), monthFields, externalGroups);
+                        table.getRows().forEach(row => {
+                            const emp = row.getData()["Employee"];
+                            monthFields.forEach(mf => {
+                                const c = row.getCell(mf);
+                                if (c) c.getElement().style.backgroundColor =
+                                    violations.has(`${emp}|${mf}`) ? "#ffcccc" : "";
+                            });
+                        });
                     });
                 });
 

--- a/sej/templates/project_details.html
+++ b/sej/templates/project_details.html
@@ -119,7 +119,7 @@
             dropdown.addEventListener("click", e => e.stopPropagation());
         }
 
-        function initTables(months, fte, people) {
+        function initTables(months, fte_rows, people) {
             document.getElementById("project-placeholder").style.display = "none";
 
             const fteColDefs = [
@@ -133,7 +133,7 @@
             ];
 
             fteTable = new Tabulator("#fte-table", {
-                data: [fte],
+                data: fte_rows,
                 columns: fteColDefs,
                 layout: "fitDataFill",
             });
@@ -162,11 +162,11 @@
                     if (!r.ok) return r.text().then(t => { throw new Error(`Server error ${r.status}: ${t}`); });
                     return r.json();
                 })
-                .then(({ months, fte, people }) => {
+                .then(({ months, fte_rows, people }) => {
                     if (fteTable === null) {
-                        initTables(months, fte, people);
+                        initTables(months, fte_rows, people);
                     } else {
-                        fteTable.setData([fte]);
+                        fteTable.setData(fte_rows);
                         peopleTable.setData(people);
                     }
                 })


### PR DESCRIPTION
## Summary

- Adds `is_internal` flag to `groups` table (with migration for existing DBs), allowing groups to be marked as external (e.g. partner organizations)
- New `/api/group` endpoint and "Add group" button in edit mode to create internal or external groups
- External group employees are excluded from: violation highlighting, fix-totals, non-project reports (by group and by person), and the group details dropdown
- Project details FTE table now shows separate **Internal FTE** and **External FTE** rows; the external row is omitted when no external employees have effort on that project

## Bug fixes included

- Fix-totals no longer leaves red cell backgrounds after correcting violations (violations were recomputed after `replaceData` instead of before)
- Group details dropdown was rendering `[object Object]` instead of group names (fixed alongside the internal-only filter)

## Test plan

- [ ] All 178 tests pass (`uv run pytest`)
- [ ] Create an external group in edit mode; confirm its employees are excluded from non-project reports and the group details dropdown
- [ ] Confirm external employees appear in the main effort table and project details (people section and External FTE row)
- [ ] Confirm fix-totals clears red highlighting correctly after running