### PR TITLE
Project Details: budget-line drilldowns, compact charts, and projected balance summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md
+
+## Required startup step
+- Before handling any user request in this repository, read `CLAUDE.md` and follow its instructions.

--- a/sej/templates/project_details.html
+++ b/sej/templates/project_details.html
@@ -45,6 +45,13 @@
         }
         #project-info dt { font-weight: 600; color: #495057; }
         #project-info dd { margin: 0; }
+        #project-info .budget-line-list {
+            margin: 0;
+            padding-left: 1.1rem;
+        }
+        #project-info .budget-line-list li {
+            margin: 0.1rem 0;
+        }
         #people-table .tabulator-tableholder { padding-bottom: 17px; }
         #spending-section { display: none; margin-top: 1.5rem; }
         .spending-chart-wrap {
@@ -227,6 +234,31 @@
                 dl.appendChild(dt);
                 dl.appendChild(dd);
             });
+
+            const budgetLines = Array.isArray(info.budget_lines) ? info.budget_lines : [];
+            if (budgetLines.length > 0) {
+                const dt = document.createElement("dt");
+                dt.textContent = budgetLines.length === 1 ? "Budget Line" : "Budget Lines";
+                const dd = document.createElement("dd");
+                const ul = document.createElement("ul");
+                ul.className = "budget-line-list";
+
+                budgetLines.forEach(bl => {
+                    const li = document.createElement("li");
+                    const name = bl.name || bl.code || "(unnamed)";
+                    const code = bl.code ? ` (${bl.code})` : "";
+                    const parts = [];
+                    if (bl.start || bl.end) parts.push(`${bl.start || "?"} to ${bl.end || "?"}`);
+                    if (bl.personnel_budget != null) parts.push("$" + bl.personnel_budget.toLocaleString());
+                    const meta = parts.length > 0 ? ` — ${parts.join(" · ")}` : "";
+                    li.textContent = `${name}${code}${meta}`;
+                    ul.appendChild(li);
+                });
+
+                dd.appendChild(ul);
+                dl.appendChild(dt);
+                dl.appendChild(dd);
+            }
             panel.style.display = "block";
         }
 

--- a/sej/templates/project_details.html
+++ b/sej/templates/project_details.html
@@ -54,14 +54,44 @@
             margin: 0.1rem 0;
         }
         #people-table .tabulator-tableholder { padding-bottom: 17px; }
+        #spending-summary-section { display: none; margin-top: 1.25rem; }
+        #spending-summary-table {
+            width: 100%;
+            max-width: 780px;
+            border-collapse: collapse;
+            background: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        #spending-summary-table th,
+        #spending-summary-table td {
+            padding: 6px 10px;
+            border-bottom: 1px solid #f0f0f0;
+            text-align: left;
+            font-size: 0.92em;
+        }
+        #spending-summary-table th {
+            background: #f5f7fa;
+            color: #495057;
+            font-weight: 600;
+        }
+        #spending-summary-table td:last-child {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+        #spending-summary-table tr.budget-line-row td {
+            background: #eef3fb;
+        }
         #spending-section { display: none; margin-top: 1.5rem; }
         .spending-chart-wrap {
             background: #fff;
             border: 1px solid #dee2e6;
             border-radius: 4px;
-            padding: 1rem;
-            max-width: 900px;
-            margin-bottom: 1rem;
+            padding: 0.6rem;
+            max-width: 520px;
+            height: 190px;
+            margin-bottom: 0.7rem;
         }
         #bl-spending-section { display: none; margin-top: 1.5rem; }
         #history-section { display: none; margin-top: 1.5rem; }
@@ -95,6 +125,16 @@
             border-bottom: 1px solid #f0f0f0;
         }
         .history-group .arrow { color: #6c757d; }
+        #fte-table .tabulator-data-tree-control,
+        #people-table .tabulator-data-tree-control {
+            display: none !important;
+        }
+        .tabulator-tree-level-1 {
+            background-color: #eef3fb !important;
+        }
+        .tabulator-tree-level-1 .tabulator-cell {
+            background-color: #eef3fb !important;
+        }
     </style>
 </head>
 <body>
@@ -117,6 +157,7 @@
     <div id="fte-section">
         <h2>Total FTE by Month</h2>
         <div class="toolbar">
+            <button id="fte-tree-btn">Expand budget lines</button>
             <div class="col-picker">
                 <button id="fte-col-btn">Columns &#9660;</button>
                 <div id="fte-col-dropdown" class="col-dropdown"></div>
@@ -128,6 +169,7 @@
     <div id="people-section">
         <h2>Individual Effort by Month</h2>
         <div class="toolbar">
+            <button id="people-tree-btn">Expand budget lines</button>
             <div class="col-picker">
                 <button id="people-col-btn">Columns &#9660;</button>
                 <div id="people-col-dropdown" class="col-dropdown"></div>
@@ -137,6 +179,20 @@
     </div>
 
     <div id="spending-section">
+        <div id="spending-summary-section">
+            <h2>Projected Balances</h2>
+            <table id="spending-summary-table">
+                <thead>
+                    <tr>
+                        <th>Project/BudgetLine</th>
+                        <th>End Date</th>
+                        <th>Projected Balance</th>
+                    </tr>
+                </thead>
+                <tbody id="spending-summary-body"></tbody>
+            </table>
+        </div>
+
         <h2>Remaining Personnel Budget</h2>
         <div class="spending-chart-wrap">
             <canvas id="spending-chart"></canvas>
@@ -160,6 +216,11 @@
         let spendingChart = null;
         let blCharts = [];
         let allProjects = [];
+        let fteTreeExpanded = false;
+        let peopleTreeExpanded = false;
+        let currentMonths = [];
+        let currentFteRows = [];
+        let currentPeopleRows = [];
 
         function fteFormatter(cell) {
             const v = cell.getValue();
@@ -205,8 +266,8 @@
                 lbl.appendChild(document.createTextNode("\u00a0" + col.getDefinition().title));
                 dropdown.appendChild(lbl);
             });
-            btn.addEventListener("click", e => { e.stopPropagation(); dropdown.classList.toggle("open"); });
-            dropdown.addEventListener("click", e => e.stopPropagation());
+            btn.onclick = e => { e.stopPropagation(); dropdown.classList.toggle("open"); };
+            dropdown.onclick = e => e.stopPropagation();
         }
 
         function showProjectInfo(info) {
@@ -347,6 +408,7 @@
                 },
                 options: {
                     responsive: true,
+                    maintainAspectRatio: false,
                     plugins: {
                         legend: { display: false },
                         tooltip: {
@@ -365,6 +427,64 @@
                     },
                 },
             });
+        }
+
+        function formatCurrency(value) {
+            if (value == null || !Number.isFinite(value)) return "";
+            return "$" + value.toLocaleString(undefined, {maximumFractionDigits: 2});
+        }
+
+        function projectedBalance(analysis) {
+            if (!analysis || analysis.length === 0) return null;
+            const last = analysis[analysis.length - 1];
+            return Number.isFinite(last.remaining) ? last.remaining : null;
+        }
+
+        function showSpendingSummary(projectInfo, projectSpending, blSpending) {
+            const section = document.getElementById("spending-summary-section");
+            const body = document.getElementById("spending-summary-body");
+            body.innerHTML = "";
+
+            const rows = [];
+            const projectRemaining = projectedBalance(projectSpending);
+            if (projectInfo && projectRemaining != null) {
+                rows.push({
+                    name: projectInfo.name || "Project",
+                    end: projectInfo.end || "",
+                    remaining: projectRemaining,
+                });
+            }
+
+            (blSpending || []).forEach(bl => {
+                const remaining = projectedBalance(bl.spending_analysis);
+                if (remaining == null) return;
+                const name = bl.code ? `${bl.name} (${bl.code})` : bl.name;
+                rows.push({
+                    name,
+                    end: bl.end || "",
+                    remaining,
+                    isBudgetLine: true,
+                });
+            });
+
+            if (rows.length === 0) {
+                section.style.display = "none";
+                return;
+            }
+
+            rows.forEach(r => {
+                const tr = document.createElement("tr");
+                if (r.isBudgetLine) tr.className = "budget-line-row";
+                const c1 = document.createElement("td");
+                c1.textContent = r.name;
+                const c2 = document.createElement("td");
+                c2.textContent = r.end;
+                const c3 = document.createElement("td");
+                c3.textContent = formatCurrency(r.remaining);
+                tr.append(c1, c2, c3);
+                body.appendChild(tr);
+            });
+            section.style.display = "block";
         }
 
         function showSpendingChart(data) {
@@ -417,32 +537,76 @@
             });
         }
 
-        function initTables(months, fte_rows, people) {
-            document.getElementById("project-placeholder").style.display = "none";
-
+        function buildFteTable(expanded) {
             const fteColDefs = [
                 { title: "Label", field: "label", frozen: true },
-                ...months.map(fteColDef),
+                ...currentMonths.map(fteColDef),
             ];
+            if (fteTable) fteTable.destroy();
+            fteTable = new Tabulator("#fte-table", {
+                data: currentFteRows,
+                columns: fteColDefs,
+                layout: "fitDataFill",
+                dataTree: true,
+                dataTreeStartExpanded: expanded,
+            });
+            fteTable.on("tableBuilt", () => setupColPicker("fte-col-btn", "fte-col-dropdown", fteTable));
+        }
+
+        function buildPeopleTable(expanded) {
             const peopleColDefs = [
                 { title: "Name", field: "name", headerFilter: "input", frozen: true },
                 { title: "Group", field: "group", headerFilter: "input" },
-                ...months.map(pctColDef),
+                ...currentMonths.map(pctColDef),
             ];
-
-            fteTable = new Tabulator("#fte-table", {
-                data: fte_rows,
-                columns: fteColDefs,
-                layout: "fitDataFill",
-            });
+            if (peopleTable) peopleTable.destroy();
             peopleTable = new Tabulator("#people-table", {
-                data: people,
+                data: currentPeopleRows,
                 columns: peopleColDefs,
                 layout: "fitDataFill",
+                dataTree: true,
+                dataTreeStartExpanded: expanded,
             });
-
-            fteTable.on("tableBuilt", () => setupColPicker("fte-col-btn", "fte-col-dropdown", fteTable));
             peopleTable.on("tableBuilt", () => setupColPicker("people-col-btn", "people-col-dropdown", peopleTable));
+        }
+
+        function initTables(months, fte_rows, people) {
+            document.getElementById("project-placeholder").style.display = "none";
+            currentMonths = months;
+            currentFteRows = fte_rows;
+            currentPeopleRows = people;
+            buildFteTable(false);
+            buildPeopleTable(false);
+            resetTreeButtons();
+        }
+
+        function setTreeExpanded(table, expand) {
+            if (table === fteTable) buildFteTable(expand);
+            if (table === peopleTable) buildPeopleTable(expand);
+            return Promise.resolve();
+        }
+
+        function hasTreeRows(rows) {
+            return rows.some(row => Array.isArray(row._children) && row._children.length > 0);
+        }
+
+        function resetTreeButtons() {
+            fteTreeExpanded = false;
+            peopleTreeExpanded = false;
+
+            const fteBtn = document.getElementById("fte-tree-btn");
+            const peopleBtn = document.getElementById("people-tree-btn");
+
+            if (currentFteRows.length > 0) {
+                const fteHasChildren = hasTreeRows(currentFteRows);
+                fteBtn.textContent = "Expand budget lines";
+                fteBtn.disabled = !fteHasChildren;
+            }
+            if (currentPeopleRows.length > 0) {
+                const peopleHasChildren = hasTreeRows(currentPeopleRows);
+                peopleBtn.textContent = "Expand budget lines";
+                peopleBtn.disabled = !peopleHasChildren;
+            }
         }
 
         function showError(msg) {
@@ -489,13 +653,18 @@
                 })
                 .then(({ months, fte_rows, people, project_info, spending_analysis, budget_line_spending }) => {
                     showProjectInfo(project_info);
+                    showSpendingSummary(project_info, spending_analysis, budget_line_spending);
                     showSpendingChart(spending_analysis);
                     showBudgetLineSpending(budget_line_spending);
                     if (fteTable === null) {
                         initTables(months, fte_rows, people);
                     } else {
-                        fteTable.setData(fte_rows);
-                        peopleTable.setData(people);
+                        currentMonths = months;
+                        currentFteRows = fte_rows;
+                        currentPeopleRows = people;
+                        buildFteTable(false);
+                        buildPeopleTable(false);
+                        resetTreeButtons();
                     }
                 })
                 .catch(err => showError(err.message));
@@ -531,6 +700,24 @@
             const projectId = findProjectIdByInput(e.target.value);
             if (!projectId) return;
             loadProject(projectId);
+        });
+
+        document.getElementById("fte-tree-btn").addEventListener("click", () => {
+            if (!fteTable) return;
+            fteTreeExpanded = !fteTreeExpanded;
+            setTreeExpanded(fteTable, fteTreeExpanded).then(() => {
+                document.getElementById("fte-tree-btn").textContent = fteTreeExpanded
+                    ? "Collapse budget lines" : "Expand budget lines";
+            });
+        });
+
+        document.getElementById("people-tree-btn").addEventListener("click", () => {
+            if (!peopleTable) return;
+            peopleTreeExpanded = !peopleTreeExpanded;
+            setTreeExpanded(peopleTable, peopleTreeExpanded).then(() => {
+                document.getElementById("people-tree-btn").textContent = peopleTreeExpanded
+                    ? "Collapse budget lines" : "Expand budget lines";
+            });
         });
 
         document.addEventListener("click", () => {

--- a/sej/templates/project_details.html
+++ b/sej/templates/project_details.html
@@ -13,7 +13,8 @@
         nav a:hover { text-decoration: underline; }
         .controls { margin-bottom: 1rem; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
         .controls label { font-weight: 600; }
-        .controls select { padding: 4px 8px; font-size: 1em; }
+        .controls input[type="text"] { padding: 4px 8px; font-size: 1em; }
+        #project-picker { min-width: 360px; }
         h2 { margin: 1.25rem 0 0.4rem; font-size: 1.05em; color: #343a40; }
         h3 { margin: 1rem 0 0.3rem; font-size: 0.95em; color: #495057; }
         .toolbar { margin-bottom: 0.5rem; display: flex; align-items: center; gap: 8px; }
@@ -101,10 +102,9 @@
     <nav><a href="/reports">&larr; Reports</a></nav>
 
     <div class="controls">
-        <label for="project-select">Project:</label>
-        <select id="project-select">
-            <option value="">Loading&hellip;</option>
-        </select>
+        <label for="project-picker">Project:</label>
+        <input id="project-picker" type="text" list="project-options" placeholder="Start typing project name...">
+        <datalist id="project-options"></datalist>
     </div>
 
     <div id="error"></div>
@@ -159,6 +159,7 @@
         let peopleTable = null;
         let spendingChart = null;
         let blCharts = [];
+        let allProjects = [];
 
         function fteFormatter(cell) {
             const v = cell.getValue();
@@ -450,6 +451,27 @@
             el.style.display = "";
         }
 
+        function renderProjectOptions() {
+            const list = document.getElementById("project-options");
+            list.innerHTML = "";
+            allProjects.forEach(p => {
+                const opt = document.createElement("option");
+                opt.value = p.name;
+                list.appendChild(opt);
+            });
+        }
+
+        function findProjectIdByInput(value) {
+            if (!value) return "";
+            const exact = allProjects.find(p => p.name === value);
+            if (exact) return exact.id;
+            const lower = value.trim().toLowerCase();
+            if (!lower) return "";
+            const partial = allProjects.filter(p => p.name.toLowerCase().includes(lower));
+            if (partial.length === 1) return partial[0].id;
+            return "";
+        }
+
         function loadProject(projectId) {
             document.getElementById("error").style.display = "none";
             if (!projectId) {
@@ -490,21 +512,26 @@
         fetch("/api/projects")
             .then(r => r.json())
             .then(projects => {
-                const sel = document.getElementById("project-select");
-                sel.innerHTML = '<option value="">-- select a project --</option>';
-                projects.forEach(p => {
-                    const opt = document.createElement("option");
-                    opt.value = p.id;
-                    opt.textContent = p.name;
-                    sel.appendChild(opt);
-                });
+                allProjects = projects;
+                renderProjectOptions();
                 if (projects.length === 1) {
-                    sel.value = projects[0].id;
+                    document.getElementById("project-picker").value = projects[0].name;
                     loadProject(projects[0].id);
                 }
             });
 
-        document.getElementById("project-select").addEventListener("change", e => loadProject(e.target.value));
+        document.getElementById("project-picker").addEventListener("input", e => {
+            const projectId = findProjectIdByInput(e.target.value);
+            if (!projectId) return;
+            loadProject(projectId);
+        });
+
+        document.getElementById("project-picker").addEventListener("keydown", e => {
+            if (e.key !== "Enter") return;
+            const projectId = findProjectIdByInput(e.target.value);
+            if (!projectId) return;
+            loadProject(projectId);
+        });
 
         document.addEventListener("click", () => {
             document.querySelectorAll(".col-dropdown").forEach(d => d.classList.remove("open"));

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1742,6 +1742,20 @@ def test_api_project_details_structure(main_client, loaded_db):
     assert "budget_line_spending" in data
 
 
+def test_api_project_details_includes_budget_line_info(main_client, loaded_db):
+    pid = _project_id_for(loaded_db, "Widget Project")
+    data = main_client.get(f"/api/project-details?project_id={pid}").json
+    assert "project_info" in data
+    assert "budget_lines" in data["project_info"]
+    assert len(data["project_info"]["budget_lines"]) >= 1
+    bl = data["project_info"]["budget_lines"][0]
+    assert "code" in bl
+    assert "name" in bl
+    assert "start" in bl
+    assert "end" in bl
+    assert "personnel_budget" in bl
+
+
 def test_api_project_details_months(main_client, loaded_db):
     pid = _project_id_for(loaded_db, "Widget Project")
     data = main_client.get(f"/api/project-details?project_id={pid}").json

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -3,7 +3,7 @@ import pytest
 import tempfile
 from pathlib import Path
 
-from sej.importer import load_tsv, load_tsv_as_branch, NON_PROJECT_CODE
+from sej.importer import load_tsv, load_tsv_as_branch, augment_sample_data, NON_PROJECT_CODE
 
 
 HEADER = [
@@ -11,6 +11,16 @@ HEADER = [
     "Cost Code 1", "Cost Code 2", "Cost Code 3", "Program Code",
     "Project Id", "Project Name",
     "July 2025", "August 2025",
+]
+
+# Extended header covering all 12 months for augmentation tests
+HEADER_FULL = [
+    "EMPLOYEE", "Group", "Fund Code", "Source", "Account",
+    "Cost Code 1", "Cost Code 2", "Cost Code 3", "Program Code",
+    "Project Id", "Project Name",
+    "July 2025", "August 2025", "September 2025", "October 2025",
+    "November 2025", "December 2025", "January 2026", "February 2026",
+    "March 2026", "April 2026", "May 2026", "June 2026",
 ]
 
 
@@ -224,3 +234,171 @@ def test_load_as_branch_creates_change_set(tmp):
     from sej.changelog import get_open_change_set
     assert get_open_change_set(conn) is not None
     conn.close()
+
+
+# --- Augmentation tests ---
+
+def write_tsv_full(path: Path, rows: list[list[str]]) -> None:
+    """Write a TSV with the full 12-month header."""
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh, delimiter="\t")
+        writer.writerow(HEADER_FULL)
+        writer.writerows(rows)
+
+
+def _make_augment_db(tmp):
+    """Create a DB with two projects (one with 2 employees, one with 1) spanning all 12 months."""
+    tsv = tmp / "augment_anon.tsv"
+    db = tmp / "augment_anon.db"
+    # Project A (5140001): 2 employees — should be picked as candidate
+    # Project B (5140002): 1 employee
+    pct = "10.00%"
+    write_tsv_full(tsv, [
+        # Employee 1, project A
+        ["Alpha,Ann", "TeamA", "25210", "49000", "511120", "", "", "", "VRENG",
+         "5140001", "Project Alpha",
+         pct, pct, pct, pct, pct, pct, pct, pct, pct, pct, pct, pct],
+        # Employee 2, project A (continuation row — blank employee = same employee)
+        ["Beta,Bob", "TeamA", "25210", "49000", "511120", "", "", "", "VRENG",
+         "5140001", "Project Alpha",
+         pct, pct, pct, pct, pct, pct, pct, pct, pct, pct, pct, pct],
+        # Employee 3, project B
+        ["Gamma,Gail", "TeamB", "30100", "50000", "522220", "", "", "", "VROPS",
+         "5140002", "Project Beta",
+         "20.00%", "20.00%", "", "", "", "", "", "", "", "", "", ""],
+    ])
+    load_tsv(tsv, db)
+    return db
+
+
+def test_augment_picks_project_and_sets_metadata(tmp):
+    db = _make_augment_db(tmp)
+    result = augment_sample_data(db)
+    assert result == "Project Alpha"
+
+    from sej.db import get_connection
+    conn = get_connection(db)
+    proj = conn.execute("""
+        SELECT * FROM projects
+        WHERE is_nonproject = 0 AND start_year IS NOT NULL
+    """).fetchone()
+    assert proj is not None
+    assert proj["start_year"] == 2025
+    assert proj["start_month"] == 7
+    assert proj["end_year"] == 2026
+    assert proj["end_month"] == 6
+    assert proj["local_pi_id"] is not None
+    assert proj["admin_group_id"] is not None
+
+    # The picked project should be the one with most employees (Project Alpha)
+    assert proj["name"] == "Project Alpha"
+    conn.close()
+
+
+def test_augment_splits_budget_line_into_y1_y2(tmp):
+    db = _make_augment_db(tmp)
+    augment_sample_data(db)
+
+    from sej.db import get_connection
+    conn = get_connection(db)
+
+    y1 = conn.execute(
+        "SELECT * FROM budget_lines WHERE budget_line_code = '5140001'"
+    ).fetchone()
+    assert y1["start_year"] == 2025
+    assert y1["start_month"] == 7
+    assert y1["end_year"] == 2026
+    assert y1["end_month"] == 2
+    assert "Y1" in y1["display_name"]
+
+    y2 = conn.execute(
+        "SELECT * FROM budget_lines WHERE budget_line_code = '5140001-Y2'"
+    ).fetchone()
+    assert y2 is not None
+    assert y2["start_year"] == 2026
+    assert y2["start_month"] == 3
+    assert y2["end_year"] == 2026
+    assert y2["end_month"] == 6
+    assert "Y2" in y2["display_name"]
+
+    # Both belong to the same project
+    assert y1["project_id"] == y2["project_id"]
+    conn.close()
+
+
+def test_augment_efforts_split_correctly(tmp):
+    db = _make_augment_db(tmp)
+    augment_sample_data(db)
+
+    from sej.db import get_connection
+    conn = get_connection(db)
+
+    y1_bl = conn.execute(
+        "SELECT id FROM budget_lines WHERE budget_line_code = '5140001'"
+    ).fetchone()
+    y2_bl = conn.execute(
+        "SELECT id FROM budget_lines WHERE budget_line_code = '5140001-Y2'"
+    ).fetchone()
+
+    # Y1 efforts: July 2025 through Feb 2026 (months 7-12 of 2025, 1-2 of 2026)
+    y1_efforts = conn.execute("""
+        SELECT e.year, e.month FROM efforts e
+        JOIN allocation_lines al ON al.id = e.allocation_line_id
+        WHERE al.budget_line_id = ?
+        ORDER BY e.year, e.month
+    """, (y1_bl["id"],)).fetchall()
+
+    y1_months = [(r["year"], r["month"]) for r in y1_efforts]
+    for ym in y1_months:
+        # All Y1 efforts should be before March 2026
+        assert ym < (2026, 3), f"Y1 has effort in {ym} which should be on Y2"
+
+    # Y2 efforts: March 2026 through June 2026
+    y2_efforts = conn.execute("""
+        SELECT e.year, e.month FROM efforts e
+        JOIN allocation_lines al ON al.id = e.allocation_line_id
+        WHERE al.budget_line_id = ?
+        ORDER BY e.year, e.month
+    """, (y2_bl["id"],)).fetchall()
+
+    y2_months = [(r["year"], r["month"]) for r in y2_efforts]
+    for ym in y2_months:
+        assert ym >= (2026, 3), f"Y2 has effort in {ym} which should be on Y1"
+
+    # Should have efforts on both sides (2 employees × 8 months on Y1, 2 × 4 on Y2)
+    assert len(y1_months) == 16  # 2 employees × 8 months (Jul-Feb)
+    assert len(y2_months) == 8   # 2 employees × 4 months (Mar-Jun)
+    conn.close()
+
+
+def test_augment_sets_personnel_budgets(tmp):
+    db = _make_augment_db(tmp)
+    augment_sample_data(db)
+
+    from sej.db import get_connection
+    conn = get_connection(db)
+
+    y1 = conn.execute(
+        "SELECT personnel_budget FROM budget_lines WHERE budget_line_code = '5140001'"
+    ).fetchone()
+    y2 = conn.execute(
+        "SELECT personnel_budget FROM budget_lines WHERE budget_line_code = '5140001-Y2'"
+    ).fetchone()
+
+    assert y1["personnel_budget"] is not None
+    assert y1["personnel_budget"] > 0
+    assert y2["personnel_budget"] is not None
+    assert y2["personnel_budget"] > 0
+    conn.close()
+
+
+def test_augment_noop_when_no_projects(tmp):
+    """Augmentation gracefully does nothing if there are no non-sentinel projects."""
+    tsv = tmp / "empty_anon.tsv"
+    db = tmp / "empty_anon.db"
+    write_tsv_full(tsv, [
+        ["Solo,Sam", "TeamX", "20152", "12001", "512120", "", "", "", "VROPS",
+         "N/A", "N/A", "100.00%", "", "", "", "", "", "", "", "", "", "", ""],
+    ])
+    load_tsv(tsv, db)
+    assert augment_sample_data(db) is None  # should not raise, returns None


### PR DESCRIPTION
## Summary
- add budget-line child rows to Project Details API for FTE and individual effort tables
- add per-table expand/collapse controls for budget-line drilldowns
- keep single-child person rows expandable so users can always see the underlying budget line
- compact the spending charts and add a projected balance summary table with project and budget-line rows
- tint budget-line rows in the summary table for readability

## Validation
- uv run pytest tests/test_app.py -k "project_details"